### PR TITLE
Remove __len__ implementation from classes that represent huge collections

### DIFF
--- a/src/pyatf/range.py
+++ b/src/pyatf/range.py
@@ -4,7 +4,7 @@ from typing import Optional, Callable, Union
 
 
 class Range:
-    def __len__(self):
+    def num_values(self):
         raise NotImplementedError
 
     def __iter__(self):
@@ -90,7 +90,7 @@ class Interval(Range):
             yield self._generator(next_value)
             next_value += self._step
 
-    def __len__(self):
+    def num_values(self):
         return self._num_values
 
     def __iter__(self):
@@ -121,7 +121,7 @@ class Set(Range):
         self._values = tuple(values)
         self._num_values = len(values)
 
-    def __len__(self):
+    def num_values(self):
         return self._num_values
 
     def __iter__(self):

--- a/src/pyatf/tuner.py
+++ b/src/pyatf/tuner.py
@@ -102,7 +102,7 @@ class Tuner:
             # prepare abort condition
             self._abort_condition = abort_condition
             if self._abort_condition is None:
-                self._abort_condition = Evaluations(len(self._search_space))
+                self._abort_condition = Evaluations(self._search_space.constrained_size)
 
             # open log file
             if log_file:
@@ -189,7 +189,7 @@ class Tuner:
 
             # initialize search technique
             if isinstance(self._search_technique, SearchTechnique1D):
-                self._search_technique.initialize(len(self._search_space))
+                self._search_technique.initialize(self._search_space.constrained_size)
             else:
                 self._search_technique.initialize(self._search_space.num_tps)
 

--- a/tests/test_range.py
+++ b/tests/test_range.py
@@ -7,103 +7,84 @@ class TestInterval(unittest.TestCase):
     def test_single_element_interval(self):
         r = Interval(3, 3)
         self.assertSequenceEqual([3], list(r))
-        self.assertEqual(1, len(r))
         self.assertEqual(3, r[0])
 
         r = Interval(3, 3, 1)
         self.assertSequenceEqual([3], list(r))
-        self.assertEqual(1, len(r))
         self.assertEqual(3, r[0])
 
         r = Interval(3, 3, 1, lambda i: 2 * i)
         self.assertSequenceEqual([6], list(r))
-        self.assertEqual(1, len(r))
         self.assertEqual(6, r[0])
 
         r = Interval(3.0, 3.0)
         self.assertSequenceEqual([3.0], list(r))
-        self.assertEqual(1, len(r))
         self.assertEqual(3.0, r[0])
 
         r = Interval(3.0, 3.0, 1.0)
         self.assertSequenceEqual([3.0], list(r))
-        self.assertEqual(1, len(r))
         self.assertEqual(3.0, r[0])
 
         r = Interval(3.0, 3.0, 1.0, lambda i: 2.0 * i)
         self.assertSequenceEqual([6.0], list(r))
-        self.assertEqual(1, len(r))
         self.assertEqual(6.0, r[0])
 
     def test_empty_interval(self):
         r = Interval(5, 3)
         self.assertSequenceEqual([], list(r))
-        self.assertEqual(0, len(r))
 
         r = Interval(5, 3, 2)
         self.assertSequenceEqual([], list(r))
-        self.assertEqual(0, len(r))
 
         r = Interval(3, 5, -2, lambda i: 2 * i)
         self.assertSequenceEqual([], list(r))
-        self.assertEqual(0, len(r))
 
         r = Interval(5.0, 3.0)
         self.assertSequenceEqual([], list(r))
-        self.assertEqual(0, len(r))
 
         r = Interval(5.0, 3.0, 2.0)
         self.assertSequenceEqual([], list(r))
-        self.assertEqual(0, len(r))
 
         r = Interval(3.0, 5.0, -2.0, lambda i: 2.0 * i)
         self.assertSequenceEqual([], list(r))
-        self.assertEqual(0, len(r))
 
     def test_multi_element_interval(self):
         r = Interval(3, 5)
         self.assertSequenceEqual([3, 4, 5], list(r))
-        self.assertEqual(3, len(r))
         self.assertEqual(3, r[0])
         self.assertEqual(4, r[1])
         self.assertEqual(5, r[2])
 
         r = Interval(3, 5, 2)
         self.assertSequenceEqual([3, 5], list(r))
-        self.assertEqual(2, len(r))
         self.assertEqual(3, r[0])
         self.assertEqual(5, r[1])
 
         r = Interval(3, 8, 2)
         self.assertSequenceEqual([3, 5, 7], list(r))
-        self.assertEqual(3, len(r))
         self.assertEqual(3, r[0])
         self.assertEqual(5, r[1])
         self.assertEqual(7, r[2])
 
         r = Interval(5, 3, -2)
         self.assertSequenceEqual([5, 3], list(r))
-        self.assertEqual(2, len(r))
         self.assertEqual(5, r[0])
         self.assertEqual(3, r[1])
 
         r = Interval(8, 3, -2)
         self.assertSequenceEqual([8, 6, 4], list(r))
-        self.assertEqual(3, len(r))
         self.assertEqual(8, r[0])
         self.assertEqual(6, r[1])
         self.assertEqual(4, r[2])
 
         r = Interval(3.0, 5.0)
         self.assertSequenceEqual([3.0, 4.0, 5.0], list(r))
-        self.assertEqual(3, len(r))
         self.assertEqual(3.0, r[0])
         self.assertEqual(4.0, r[1])
         self.assertEqual(5.0, r[2])
 
         r = Interval(3.0, 5.0, 0.5)
         self.assertSequenceEqual([3.0, 3.5, 4.0, 4.5, 5.0], list(r))
-        self.assertEqual(5, len(r))
         self.assertEqual(3.0, r[0])
         self.assertEqual(3.5, r[1])
         self.assertEqual(4.0, r[2])
@@ -112,7 +93,6 @@ class TestInterval(unittest.TestCase):
 
         r = Interval(3.0, 5.0, 0.3)
         self.assertSequenceEqual([3.0, 3.3, 3.6, 3.9, 4.2, 4.5, 4.8], list(r))
-        self.assertEqual(7, len(r))
         self.assertEqual(3.0, r[0])
         self.assertEqual(3.3, r[1])
         self.assertEqual(3.6, r[2])
@@ -123,7 +103,6 @@ class TestInterval(unittest.TestCase):
 
         r = Interval(5.0, 3.0, -0.5)
         self.assertSequenceEqual([5.0, 4.5, 4.0, 3.5, 3.0], list(r))
-        self.assertEqual(5, len(r))
         self.assertEqual(5.0, r[0])
         self.assertEqual(4.5, r[1])
         self.assertEqual(4.0, r[2])
@@ -132,7 +111,6 @@ class TestInterval(unittest.TestCase):
 
         r = Interval(5.0, 3.0, -0.3)
         self.assertSequenceEqual([5.0, 4.7, 4.4, 4.1, 3.8, 3.5, 3.2], list(r))
-        self.assertEqual(7, len(r))
         self.assertEqual(5.0, r[0])
         self.assertEqual(4.7, r[1])
         self.assertEqual(4.4, r[2])
@@ -151,18 +129,15 @@ class TestSet(unittest.TestCase):
     def test_empty_set(self):
         s = Set()
         self.assertSequenceEqual([], list(s))
-        self.assertEqual(0, len(s))
 
     def test_single_element_set(self):
         s = Set('val1')
         self.assertSequenceEqual(['val1'], list(s))
-        self.assertEqual(1, len(s))
         self.assertEqual('val1', s[0])
 
     def test_multi_element_set(self):
         s = Set('val1', 'val2', 'val3')
         self.assertSequenceEqual(['val1', 'val2', 'val3'], list(s))
-        self.assertEqual(3, len(s))
         self.assertEqual('val1', s[0])
         self.assertEqual('val2', s[1])
         self.assertEqual('val3', s[2])

--- a/tests/test_tuning_data.py
+++ b/tests/test_tuning_data.py
@@ -46,8 +46,8 @@ class TestTuningData(unittest.TestCase):
         search_space_generation_end = time.perf_counter_ns()
         tuning_data = TuningData(
             [tp1.to_json(), tp2.to_json(), tp3.to_json()],
-            len(search_space),
-            len(tp1.values) * len(tp2.values) * len(tp3.values),
+            search_space.constrained_size,
+            tp1.values.num_values() * tp2.values.num_values() * tp3.values.num_values(),
             search_space_generation_end - search_space_generation_start,
             Random().to_json(),
             Evaluations(6).to_json()


### PR DESCRIPTION
Remove __len__ implementation from classes that represent huge collections because it causes overflow errors